### PR TITLE
Fix tts api and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "google-home-notify",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,9 +9,14 @@
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-0.3.0.tgz",
       "integrity": "sha1-XmYjDlIZ/j6JUqTvtPIPrllqgTo=",
       "requires": {
-        "colour": "0.7.1",
-        "optjs": "3.2.2"
+        "colour": "^0.7.1",
+        "optjs": "^3.2.2"
       }
+    },
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "bufferview": {
       "version": "1.0.1",
@@ -23,8 +28,8 @@
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-3.5.5.tgz",
       "integrity": "sha1-em+vGhNRSwg/H8+VQcTJv75+f9M=",
       "requires": {
-        "bufferview": "1.0.1",
-        "long": "2.4.0"
+        "bufferview": "~1",
+        "long": "~2 >=2.2.3"
       }
     },
     "castv2": {
@@ -32,8 +37,8 @@
       "resolved": "https://registry.npmjs.org/castv2/-/castv2-0.1.9.tgz",
       "integrity": "sha1-0LD6sf0GsNnMpjaIZxbsEpOlkFo=",
       "requires": {
-        "debug": "2.6.8",
-        "protobufjs": "3.8.2"
+        "debug": "^2.2.0",
+        "protobufjs": "^3.2.2"
       }
     },
     "castv2-client": {
@@ -41,8 +46,8 @@
       "resolved": "https://registry.npmjs.org/castv2-client/-/castv2-client-1.2.0.tgz",
       "integrity": "sha1-qRk7GlRIuMuaBBW9AhyIEe17BUQ=",
       "requires": {
-        "castv2": "0.1.9",
-        "debug": "2.6.8"
+        "castv2": "~0.1.4",
+        "debug": "^2.2.0"
       }
     },
     "colour": {
@@ -51,9 +56,9 @@
       "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -63,21 +68,24 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.18"
+        "iconv-lite": "~0.4.13"
       }
     },
     "google-tts-api": {
-      "version": "0.0.2-alpha.1",
-      "resolved": "https://registry.npmjs.org/google-tts-api/-/google-tts-api-0.0.2-alpha.1.tgz",
-      "integrity": "sha512-ld0JojnUCHXpd6HYNm8cjsa0IOPj3EQ1YQmmOTT01ywuOxApJPxvL7Ve0uTmgKwYZxh1mNfXj9kowP3xtL58LA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/google-tts-api/-/google-tts-api-0.0.3.tgz",
+      "integrity": "sha512-bOEOAjQalxKrRLottV7dwf7KgCVYuZ8gChir1EABYD0EtquwiHb8gnRLWuNAmA30a+UPBD/x26uW935s9jFaJg==",
       "requires": {
-        "isomorphic-fetch": "2.2.1"
+        "isomorphic-fetch": "^2.2.1"
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -89,8 +97,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.2",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "long": {
@@ -104,12 +112,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node-fetch": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "optjs": {
@@ -122,14 +130,19 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-3.8.2.tgz",
       "integrity": "sha1-vIJuNMOvRpfo0K96Zp5NYSrtzRc=",
       "requires": {
-        "ascli": "0.3.0",
-        "bytebuffer": "3.5.5"
+        "ascli": "~0.3",
+        "bytebuffer": "~3 >=3.5"
       }
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "google-home-notify",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.5.2",
     "castv2-client": "^1.2.0",
-    "google-tts-api": "0.0.2-alpha.1",
-    "bluebird": "3.5.1"
+    "google-tts-api": "0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-home-notify",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "google-home-notifier.js",
   "scripts": {


### PR DESCRIPTION
Update dependencies, including google-tts-api to 0.0.3, fixes https://github.com/nabbl/node-red-contrib-google-home-notify/issues/25. Also bumps the version to 0.0.4